### PR TITLE
docs(README): install with `ya pack` to remove `init.lua` warning on yazi v25.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@
 
 ### Linux/MacOS
 
+Using the [Yazi Package Manager](https://yazi-rs.github.io/docs/cli/#package-manager):
+
+```sh
+ya pack -a kirasok/torrent-preview
+```
+
+Or manually:
+
 ```sh
 git clone https://github.com/kirasok/torrent-preview.yazi.git ~/.config/yazi/plugins/torrent-preview.yazi
 ```
@@ -29,3 +37,4 @@ run = "torrent-preview"
 
 > [!NOTE]
 > Yazi after `v0.4` removes `x-` prefix from subtype, so even if `file -i` outputs `application/x-bittorrent`, you should use `application/bittorrent` ([relevant issue](https://github.com/kirasok/torrent-preview.yazi/issues/2))
+


### PR DESCRIPTION
Since [v25.2.7](https://github.com/sxyazi/yazi/releases/tag/v25.2.7), the plugin entry point should be `main.lua`.

If we install the plugin via the CLI, `init.lua` will automatically be renamed to `main.lua`:

> When installing a plugin via ya pack, the init.lua file will be automatically renamed to main.lua to ensure a smooth transition for existing plugins.
_cf. https://github.com/sxyazi/yazi/pull/2168_

Rather than creating a symlink or something in order to both have `init.lua` and `main.lua`, to keep compatibility with Yazi <=[v0.4.2](https://github.com/sxyazi/yazi/releases/tag/v0.4.2), here is a simple tip to install the plugin with `ya pack` which automatically handles the renaming of `init.lua` to `main.lua`