### PR TITLE
fix: change deprecated ya.preview_widgets to ya.preview_widget

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -34,7 +34,7 @@ function M:peek(job)
 		ya.manager_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
+		ya.preview_widget(job, { ui.Text.parse(lines):area(job.area) })
 	end
 end
 
@@ -43,4 +43,3 @@ function M:seek(job)
 end
 
 return M
-


### PR DESCRIPTION
👋 

`ya.preview_widgets` has been deprecated

see https://github.com/sxyazi/yazi/releases/tag/v25.5.28 and https://github.com/sxyazi/yazi/pull/2706